### PR TITLE
EG Spectator module not properly hiding units after death in multiplayer

### DIFF
--- a/modules/eg_spectator_mode/init.sqf
+++ b/modules/eg_spectator_mode/init.sqf
@@ -219,7 +219,8 @@ if (!isDedicated) then {
 	FNC_SpectatingRemoteFunc = {
 		player setVariable ["FW_Dead", true, true]; //Tells the framework the player is dead
 
-		player hideObjectGlobal true;
+		[(player),true] remoteExecCall ["hideObject", 0];
+		[(player),true] remoteExecCall ["hideObjectGlobal", 2];
 		player setCaptive true;
 		player allowDamage false;
 


### PR DESCRIPTION
EG Spectator module not properly hiding units after death in multiplayer. This fixes it.